### PR TITLE
Add linux_aarch64 support

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,22 +8,38 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_numpy1.20python3.8.____cpython:
-        CONFIG: linux_64_numpy1.20python3.8.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
-      linux_64_numpy1.20python3.9.____cpython:
-        CONFIG: linux_64_numpy1.20python3.9.____cpython
-        UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_numpy1.21python3.10.____cpython:
         CONFIG: linux_64_numpy1.21python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_numpy1.21python3.8.____cpython:
+        CONFIG: linux_64_numpy1.21python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_numpy1.21python3.9.____cpython:
+        CONFIG: linux_64_numpy1.21python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
       linux_64_numpy1.23python3.11.____cpython:
         CONFIG: linux_64_numpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_numpy1.21python3.10.____cpython:
+        CONFIG: linux_aarch64_numpy1.21python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
+      linux_aarch64_numpy1.21python3.8.____cpython:
+        CONFIG: linux_aarch64_numpy1.21python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
+      linux_aarch64_numpy1.21python3.9.____cpython:
+        CONFIG: linux_aarch64_numpy1.21python3.9.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
+      linux_aarch64_numpy1.23python3.11.____cpython:
+        CONFIG: linux_aarch64_numpy1.23python3.11.____cpython
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-aarch64
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -8,26 +8,26 @@ jobs:
     vmImage: macOS-11
   strategy:
     matrix:
-      osx_64_numpy1.20python3.8.____cpython:
-        CONFIG: osx_64_numpy1.20python3.8.____cpython
-        UPLOAD_PACKAGES: 'True'
-      osx_64_numpy1.20python3.9.____cpython:
-        CONFIG: osx_64_numpy1.20python3.9.____cpython
-        UPLOAD_PACKAGES: 'True'
       osx_64_numpy1.21python3.10.____cpython:
         CONFIG: osx_64_numpy1.21python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.21python3.8.____cpython:
+        CONFIG: osx_64_numpy1.21python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_64_numpy1.21python3.9.____cpython:
+        CONFIG: osx_64_numpy1.21python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
       osx_64_numpy1.23python3.11.____cpython:
         CONFIG: osx_64_numpy1.23python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
-      osx_arm64_numpy1.20python3.8.____cpython:
-        CONFIG: osx_arm64_numpy1.20python3.8.____cpython
-        UPLOAD_PACKAGES: 'True'
-      osx_arm64_numpy1.20python3.9.____cpython:
-        CONFIG: osx_arm64_numpy1.20python3.9.____cpython
-        UPLOAD_PACKAGES: 'True'
       osx_arm64_numpy1.21python3.10.____cpython:
         CONFIG: osx_arm64_numpy1.21python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.21python3.8.____cpython:
+        CONFIG: osx_arm64_numpy1.21python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      osx_arm64_numpy1.21python3.9.____cpython:
+        CONFIG: osx_arm64_numpy1.21python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
       osx_arm64_numpy1.23python3.11.____cpython:
         CONFIG: osx_arm64_numpy1.23python3.11.____cpython

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -8,14 +8,14 @@ jobs:
     vmImage: windows-2022
   strategy:
     matrix:
-      win_64_numpy1.20python3.8.____cpython:
-        CONFIG: win_64_numpy1.20python3.8.____cpython
-        UPLOAD_PACKAGES: 'True'
-      win_64_numpy1.20python3.9.____cpython:
-        CONFIG: win_64_numpy1.20python3.9.____cpython
-        UPLOAD_PACKAGES: 'True'
       win_64_numpy1.21python3.10.____cpython:
         CONFIG: win_64_numpy1.21python3.10.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_numpy1.21python3.8.____cpython:
+        CONFIG: win_64_numpy1.21python3.8.____cpython
+        UPLOAD_PACKAGES: 'True'
+      win_64_numpy1.21python3.9.____cpython:
+        CONFIG: win_64_numpy1.21python3.9.____cpython
         UPLOAD_PACKAGES: 'True'
       win_64_numpy1.23python3.11.____cpython:
         CONFIG: win_64_numpy1.23python3.11.____cpython

--- a/.ci_support/linux_64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.8.____cpython.yaml
@@ -1,19 +1,25 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- gxx
+cxx_compiler_version:
+- '11'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 target_platform:
-- win-64
+- linux-64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/linux_64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/linux_64_numpy1.21python3.9.____cpython.yaml
@@ -1,25 +1,25 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '14'
-macos_machine:
-- arm64-apple-darwin20.0.0
+- '11'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- osx-arm64
+- linux-64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/linux_aarch64_numpy1.21python3.10.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21python3.10.____cpython.yaml
@@ -1,25 +1,29 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '14'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '11'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.10.* *_cpython
 target_platform:
-- osx-64
+- linux-aarch64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/linux_aarch64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21python3.8.____cpython.yaml
@@ -1,0 +1,29 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '11'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+numpy:
+- '1.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/linux_aarch64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.21python3.9.____cpython.yaml
@@ -1,25 +1,29 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '10.9'
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '14'
-macos_machine:
-- x86_64-apple-darwin13.4.0
+- '11'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- osx-64
+- linux-aarch64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/linux_aarch64_numpy1.23python3.11.____cpython.yaml
+++ b/.ci_support/linux_aarch64_numpy1.23python3.11.____cpython.yaml
@@ -1,0 +1,29 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '11'
+docker_image:
+- quay.io/condaforge/linux-anvil-aarch64
+numpy:
+- '1.23'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.11.* *_cpython
+target_platform:
+- linux-aarch64
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/osx_64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.8.____cpython.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '10.9'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -9,17 +9,17 @@ cxx_compiler:
 cxx_compiler_version:
 - '14'
 macos_machine:
-- arm64-apple-darwin20.0.0
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.9.* *_cpython
+- 3.8.* *_cpython
 target_platform:
-- osx-arm64
+- osx-64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_64_numpy1.21python3.9.____cpython.yaml
@@ -1,25 +1,25 @@
-cdt_name:
-- cos6
+MACOSX_DEPLOYMENT_TARGET:
+- '10.9'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
+- clangxx
 cxx_compiler_version:
-- '11'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- '14'
+macos_machine:
+- x86_64-apple-darwin13.4.0
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
 python:
-- 3.8.* *_cpython
+- 3.9.* *_cpython
 target_platform:
-- linux-64
+- osx-64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_arm64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.8.____cpython.yaml
@@ -1,11 +1,17 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2019
+- clangxx
+cxx_compiler_version:
+- '14'
+macos_machine:
+- arm64-apple-darwin20.0.0
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -13,7 +19,7 @@ pin_run_as_build:
 python:
 - 3.8.* *_cpython
 target_platform:
-- win-64
+- osx-arm64
 zip_keys:
 - - python
   - numpy

--- a/.ci_support/osx_arm64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/osx_arm64_numpy1.21python3.9.____cpython.yaml
@@ -1,0 +1,25 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '14'
+macos_machine:
+- arm64-apple-darwin20.0.0
+numpy:
+- '1.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.9.* *_cpython
+target_platform:
+- osx-arm64
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/win_64_numpy1.21python3.8.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.21python3.8.____cpython.yaml
@@ -1,0 +1,19 @@
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- vs2019
+numpy:
+- '1.21'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.8.* *_cpython
+target_platform:
+- win-64
+zip_keys:
+- - python
+  - numpy

--- a/.ci_support/win_64_numpy1.21python3.9.____cpython.yaml
+++ b/.ci_support/win_64_numpy1.21python3.9.____cpython.yaml
@@ -1,17 +1,11 @@
-cdt_name:
-- cos6
 channel_sources:
 - conda-forge
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- gxx
-cxx_compiler_version:
-- '11'
-docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- vs2019
 numpy:
-- '1.20'
+- '1.21'
 pin_run_as_build:
   python:
     min_pin: x.x
@@ -19,7 +13,7 @@ pin_run_as_build:
 python:
 - 3.9.* *_cpython
 target_platform:
-- linux-64
+- win-64
 zip_keys:
 - - python
   - numpy

--- a/README.md
+++ b/README.md
@@ -37,24 +37,24 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64_numpy1.20python3.8.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.20python3.8.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>linux_64_numpy1.20python3.9.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.20python3.9.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>linux_64_numpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_numpy1.21python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_numpy1.21python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_numpy1.21python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -65,17 +65,31 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.20python3.8.____cpython</td>
+              <td>linux_aarch64_numpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.20python3.8.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.21python3.10.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>osx_64_numpy1.20python3.9.____cpython</td>
+              <td>linux_aarch64_numpy1.21python3.8.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.20python3.9.____cpython" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.21python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.21python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.21python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64_numpy1.23python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_aarch64_numpy1.23python3.11.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -86,24 +100,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_64_numpy1.21python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_64_numpy1.21python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.21python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_64_numpy1.23python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_numpy1.23python3.11.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>osx_arm64_numpy1.20python3.8.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.20python3.8.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>osx_arm64_numpy1.20python3.9.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.20python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>
@@ -114,6 +128,20 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64_numpy1.21python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.21python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_numpy1.21python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_numpy1.21python3.9.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>osx_arm64_numpy1.23python3.11.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
@@ -121,24 +149,24 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_64_numpy1.20python3.8.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.20python3.8.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
-              <td>win_64_numpy1.20python3.9.____cpython</td>
-              <td>
-                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.20python3.9.____cpython" alt="variant">
-                </a>
-              </td>
-            </tr><tr>
               <td>win_64_numpy1.21python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
                   <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.21python3.8.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.8.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>win_64_numpy1.21python3.9.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=7189&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/pymatgen-feedstock?branchName=main&jobName=win&configuration=win%20win_64_numpy1.21python3.9.____cpython" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -9,5 +9,6 @@ github:
   branch_name: main
   tooling_branch_name: main
 provider:
+  linux_aarch64: azure
   win: azure
 test_on_native_only: true


### PR DESCRIPTION
This will allow for builds on Linux with ARM64 architectures.
This helpful not only for building on these systems, but also for building docker containers / VMs that support OSX Mx chips

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
